### PR TITLE
Add index command to the workflow

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -10,6 +10,22 @@ colors = "config/colors.tsv",
 lat_longs = "config/lat_longs.tsv",
 auspice_config = "config/auspice_config.json"
 
+rule index_sequences:
+    message:
+        """
+        Creating an index of sequence composition for filtering.
+        """
+    input:
+        sequences = input_fasta
+    output:
+        sequence_index = "results/sequence_index.tsv"
+    shell:
+        """
+        augur index \
+            --sequences {input.sequences} \
+            --output {output.sequence_index}
+        """
+
 rule filter:
     message:
         """
@@ -20,6 +36,7 @@ rule filter:
         """
     input:
         sequences = input_fasta,
+        sequence_index = "results/sequence_index.tsv",
         metadata = input_metadata,
         exclude = dropped_strains
     output:
@@ -32,6 +49,7 @@ rule filter:
         """
         augur filter \
             --sequences {input.sequences} \
+            --sequence-index {input.sequence_index} \
             --metadata {input.metadata} \
             --exclude {input.exclude} \
             --output {output.sequences} \


### PR DESCRIPTION
Adds the new augur index command to the workflow as an example of how to precalculate sequence composition before running augur filter.

Depends on [augur index command being merged and released](https://github.com/nextstrain/augur/pull/651).