### PR TITLE
Enable entropy panel

### DIFF
--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -37,7 +37,8 @@
   ],
   "panels": [
      "tree",
-     "map"
+     "map",
+     "entropy"
   ],
   "display_defaults": {
     "map_triplicate": true


### PR DESCRIPTION
If panels are defined in the auspice-config then the entropy panel won't be automatically added. I'm assuming that the entropy panel was left out here as an oversight.
