### PR TITLE
add: color invariant regions to match the live build

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -203,6 +203,7 @@ rule export:
             --colors {input.colors} \
             --lat-longs {input.lat_longs} \
             --auspice-config {input.auspice_config} \
+            --include-root-sequence \
             --output {output.auspice_json}
         """
 


### PR DESCRIPTION
### Description of proposed changes

Add the _root-sequence.json sidecar file such that genotypes with no observed mutations can also be coloured. This matches more closely to the live builds and bypasses explaining the different behavior during training. 

### Related issue(s)

Fixes https://github.com/nextstrain/zika-tutorial/issues/9

### Testing

Assuming the reviewer has a working install of nextstrain 

```
nextstrain version
#> nextstrain.cli 4.2.0
```

Check to make sure tutorial runs and colours invariant regions:

```
git clone https://github.com/nextstrain/zika-tutorial.git
cd zika-tutorial
git checkout add_root
nextstrain build --cpus 1 .
nextstrain view auspice
```

In the browser, check a few invariant regions and that they are colored similar to:

![Screen Shot 2022-10-07 at 10 05 12 AM](https://user-images.githubusercontent.com/1077254/194614279-0f2bc495-f0b0-47ac-9f26-b3d8d19aaddf.png)
