### PR TITLE
Add prM protein, remove PRO (pr) protein

### DIFF
--- a/config/zika_outgroup.gb
+++ b/config/zika_outgroup.gb
@@ -100,9 +100,10 @@ FEATURES             Location/Qualifiers
      CDS             91..456
                      /product="capsid protein"
                      /gene="CA"
-     CDS             457..735
-                     /product="propeptide"
-                     /gene="PRO"
+     CDS             457..960
+                     /note="Modified by Nextstrain; Differs from ref"
+                     /product="precursor membrane protein"
+                     /gene="prM"
      CDS             736..960
                      /product="membrane protein"
                      /gene="MP"


### PR DESCRIPTION
The precursor protein is cleaved into ~10 proteins including the precusor membrane protein (prM). [prM is subsequently cleaved by the host protease furin resulting in protein M (aka MP).](https://www.microbiologyresearch.org/content/journal/jgv/10.1099/vir.0.18723-0)

The previous annotation included CDSs PRO and MP, but not the (parent) prM protein. prM is cleaved directly from the polyprotein and is functional, forming heterodimers with protein E (similar behaviour across all flaviviruses I believe).

[NCBI's genome viewer shows both prM as well as both the sub-proteins after cleavage, pr and M](https://www.ncbi.nlm.nih.gov/gene/7751225). pr would correspond to the previous PRO annotation. I've not seen protein pr referenced anywhere else so I've not included that here.

Note that this change wasn't desirable [before Auspice could display overlapping CDSs](https://github.com/nextstrain/auspice/pull/1684).

Here's how the resulting dataset will look in Auspice:

![image](https://github.com/nextstrain/zika-tutorial/assets/8350992/e54f4bc6-fe1f-402a-903a-6e12f2ef2561)


This will result in URLs which specified a PRO genotype colouring no longer working (the colorBy will switch to the default). As such, this PR is a good place to consider how comfortable we are with improving genome annotations in general.
