### PR TITLE
Add default profile to set Snakemake CLI args

### DIFF
--- a/profiles/default/config.yaml
+++ b/profiles/default/config.yaml
@@ -1,0 +1,4 @@
+cores: all
+rerun-incomplete: true
+printshellcmds: true
+reason: true


### PR DESCRIPTION
The special profile at `profiles/default/config.yaml` is used by snakemake >= 7.29 by default without requiring passing in via `--profile profiles/default`

Profiles are nice because they reduce number of CLI args required when invoking `snakemake`, e.g. one no longer needs to use `--cores 1` or `-c1` which became necessary in snakemake at some point.

With the default profile, one can simply run the tutorial by typing `snakemake`.