### PR TITLE
Add `nextstrain run` support

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -2,13 +2,13 @@ rule all:
     input:
         auspice_json = "auspice/zika.json",
 
-input_fasta = "data/sequences.fasta",
-input_metadata = "data/metadata.tsv",
-dropped_strains = "config/dropped_strains.txt",
-reference = "config/zika_outgroup.gb",
-colors = "config/colors.tsv",
-lat_longs = "config/lat_longs.tsv",
-auspice_config = "config/auspice_config.json"
+input_fasta = f"{workflow.basedir}/data/sequences.fasta"
+input_metadata = f"{workflow.basedir}/data/metadata.tsv"
+dropped_strains = f"{workflow.basedir}/config/dropped_strains.txt"
+reference = f"{workflow.basedir}/config/zika_outgroup.gb"
+colors = f"{workflow.basedir}/config/colors.tsv"
+lat_longs = f"{workflow.basedir}/config/lat_longs.tsv"
+auspice_config = f"{workflow.basedir}/config/auspice_config.json"
 
 rule index_sequences:
     message:

--- a/nextstrain-pathogen.yaml
+++ b/nextstrain-pathogen.yaml
@@ -1,0 +1,14 @@
+# This file's *existence* marks the top level of a Nextstrain pathogen repo,
+# which allows `nextstrain build` to be run from any subdirectory of the repo
+# regardless of runtime.  For more details, see
+# <https://github.com/nextstrain/cli/releases/tag/8.2.0>.
+#
+# This file's *contents* is the "registration metadata" for the pathogen repo,
+# used by `nextstrain setup` and `nextstrain run`.
+---
+$schema: https://nextstrain.org/schemas/pathogen/v0
+workflows:
+  phylogenetic:
+    path: .
+    compatibility:
+      nextstrain run: True


### PR DESCRIPTION
## Description of proposed changes

The goal of the repo is to present the simplest version of a phylogenetic workflow so I have kept the top level Snakefile and kept the original behavior where the input files are hard-coded in the workflow and cannot be modified via config parameters.

Requires Nextstrain CLI 10.4.0 with support for the workflow name to path mapping to be able to run with 

```
nextstrain setup zika-tutorial@nextstrain-run-support
nextstrain run zika-tutorial@nextstrain-run-support phylogenetic /tmp/zika-tutorial
```

## Related issue(s)

Resolves https://github.com/nextstrain/zika-tutorial/issues/18

